### PR TITLE
Stop the viewport metatag from hatin' on WebKit.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en-au">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width; initial-scale=0; maximum-scale=0; user-scalable=0;">
+    <meta name="viewport" content="width=device-width, initial-scale=0, maximum-scale=0, user-scalable=0">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon-precomposed" href="/images/icons/iphone.png">
     <title>most days, but today?</title>


### PR DESCRIPTION
Just fixed this in one of my apps, thought I could share the love.

FYI:

http://miniapps.co.uk/blog/post/make-sure-to-use-correct-meta-viewport-syntax/
